### PR TITLE
[회원가입] 이메일 인증 제외구현

### DIFF
--- a/src/main/java/com/boot/swlugweb/SwlugWebApplication.java
+++ b/src/main/java/com/boot/swlugweb/SwlugWebApplication.java
@@ -2,6 +2,7 @@ package com.boot.swlugweb;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
@@ -15,6 +16,10 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 		"com.boot.swlugweb.v1.login",
 		"com.boot.swlugweb.v1.signup"
 }) // 엔티티 클래스 경로 설정
+
+//@ComponentScan(
+//		excludeFilters = @ComponentScan.Filter(type = FilterType.REGEX, pattern = "com.boot.swlugweb.v1.board.*")
+//)
 public class SwlugWebApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/boot/swlugweb/v1/signup/SignupConfig.java
+++ b/src/main/java/com/boot/swlugweb/v1/signup/SignupConfig.java
@@ -1,7 +1,9 @@
 package com.boot.swlugweb.v1.signup;
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -27,4 +29,5 @@ public class SignupConfig {
 
         return http.build();
     }
+
 }

--- a/src/main/java/com/boot/swlugweb/v1/signup/SignupController.java
+++ b/src/main/java/com/boot/swlugweb/v1/signup/SignupController.java
@@ -16,7 +16,7 @@ public class SignupController {
     //회원가입 진행 -> 받는 파라미터로 이메일 인증 번호도 같이 받아야 함
     @PostMapping("/signup") //사용자가 작성한 폼을 받아옴
     public String register(@RequestBody SignupRequestDto signuprequestdto) {
-        System.out.println("User ID: " + signuprequestdto.getUser_id());
+        System.out.println("User ID: " + signuprequestdto.getUserId());
         System.out.println("Email: " + signuprequestdto.getEmail());
         System.out.println("Phone: " + signuprequestdto.getPhone());
         signupService.registerUser(signuprequestdto);

--- a/src/main/java/com/boot/swlugweb/v1/signup/SignupRequestDto.java
+++ b/src/main/java/com/boot/swlugweb/v1/signup/SignupRequestDto.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 @Setter
 public class SignupRequestDto {
 
-    private String user_id;
+    private String userId;
     private String pw;
     private String confirmPw;
     private String nickname;

--- a/src/main/java/com/boot/swlugweb/v1/signup/SignupUserInfoDomain.java
+++ b/src/main/java/com/boot/swlugweb/v1/signup/SignupUserInfoDomain.java
@@ -13,30 +13,27 @@ public class SignupUserInfoDomain {
     //user_info 테이블에 들어갈 객체 정의
 
     @Id
-    @Column(name = "user_id")
-    private String user_id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY) //auto_increment 설정
+    @Column(name = "user_info_num")
+    private Integer userInfoNum;
 
     @Version
     private Long version;
 
+    @Column(name = "email")
     private String email;
+
+    @Column(name = "phone")
     private String phone;
 
-    @OneToOne(mappedBy = "signupUserInfo", cascade = CascadeType.ALL)
+    // FK를 주테이블이 갖는 일대일 단방향 관계에서는 대상 테이블에 해당하는 클래스를 참조 필드로 작성
+    // name에 외래키 이름 작성
+    @OneToOne()
+    @JoinColumn(name = "users_num")
     private SignupUsersDomain signupUsers;
 
-    @OneToOne(mappedBy = "signupUserInfoDomain", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    @OneToOne()
+    @JoinColumn(name = "type_num")
     private SignupUserRuleTypeDomain signupUserRuleType;
 
-    //생성자 선언
-    public SignupUserInfoDomain() {}
-
-    // 연관관계 편의 메서드 (선택 사항)
-//    public void setSignupUsers(SignupUsersDomain signupUsers) {
-//        this.signupUsers = signupUsers;
-//    }
-//
-//    public void setSignupUserRuleType(SignupUserRuleTypeDomain signupUserRuleType) {
-//        this.signupUserRuleType = signupUserRuleType;
-//    }
 }

--- a/src/main/java/com/boot/swlugweb/v1/signup/SignupUserRuleTypeDomain.java
+++ b/src/main/java/com/boot/swlugweb/v1/signup/SignupUserRuleTypeDomain.java
@@ -1,7 +1,6 @@
 package com.boot.swlugweb.v1.signup;
 
 import jakarta.persistence.*;
-import jakarta.persistence.criteria.CriteriaBuilder;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,17 +11,18 @@ import lombok.Setter;
 public class SignupUserRuleTypeDomain {
 
     @Id
-    @Column(name = "user_id")
-    private String user_id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "type_num")
+    private Integer typeNum;
 
     @Version
     private Long version;
 
     private String nickname;
-    private Integer ruleType;
 
-    @OneToOne
-    @JoinColumn(name = "user_id") //객체를 여러 번 저장하는 일을 피하고자..
-    private SignupUserInfoDomain signupUserInfoDomain;
+    private Integer role_type;
+
+    private String userId;
+
 
 }

--- a/src/main/java/com/boot/swlugweb/v1/signup/SignupUsersDomain.java
+++ b/src/main/java/com/boot/swlugweb/v1/signup/SignupUsersDomain.java
@@ -11,25 +11,17 @@ import lombok.Setter;
 @Table(name ="users")
 public class SignupUsersDomain {
     //users 테이블에 들어갈 객체 정의
+
     @Id
-    @Column(name = "user_id")
-    private String user_id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "users_num")
+    private Integer usersNum;
+
 
     @Version
     private Long version;
 
     private String pw;
-
-    //test db에 맞춤
-    private Integer id;
-    private Integer account_locked;
-    private String password;
-    private Integer try_count;
     private String userId;
-
-
-
-    @OneToOne
-    @JoinColumn(name = "user_id")
-    private SignupUserInfoDomain signupUserInfo; //users_info 테이블을 참고함을 명시
+    
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -17,8 +17,9 @@ SWLUG_MYSQL_USER=root
 SWLUG_MYSQL_PW=swlug2024
 
 #table mapping strategy
-spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+#spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
 
+
 #table version manage
-spring.jpa.hibernate.ddl-auto=update
+#spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
[변경 및 구현 사항] 

- 테이블 변경에 따른 엔터티 변경 
![테이블_최종](https://github.com/user-attachments/assets/7740a2dc-de52-404b-af9f-9ce42d3bb18f)
- users, user_type, user_info 테이블에 데이터 저장까지 되는 거 확인했습니다. 

[앞으로 구현할 사항] 
- 이메일 인증 API 구현 후 회원가입 구현 마무리 지을 예정입니다.

[덧붙임] 
- 제가 pull 받았을 때 board 쪽에서 오류가 나서 main에서 해당 부분 제외하고 실행하였습니다. 일단 주석 처리 해두기는 하였는데 추후에 괜찮으면 삭제해도 될 것 같습니다. 
- signup API 테스트 노션 제 페이지에 요청 url과 json 정리해두었습니다