### PR TITLE
[mnzy] notice - 수정 시 날짜 업데이트 삭제

### DIFF
--- a/src/main/java/com/boot/swlugweb/v1/notice/NoticeService.java
+++ b/src/main/java/com/boot/swlugweb/v1/notice/NoticeService.java
@@ -105,7 +105,6 @@ public class NoticeService {
         if (noticeUpdateRequestDto.getImageUrl() != null) {
             notice.setImage(noticeUpdateRequestDto.getImageUrl());
         }
-        notice.setCreateAt(LocalDateTime.now());
 
         noticeRepository.save(notice);
     }


### PR DESCRIPTION
[notice/service] notice.setCreateAt(LocalDateTime.now()); 코드 삭제 

수정 이유: 공지사항 수정 시 게시물 날짜도 수정된 일자로 업데이트됨 